### PR TITLE
add-PlayerStartPosition

### DIFF
--- a/Assets/Scenes/main.unity
+++ b/Assets/Scenes/main.unity
@@ -541,7 +541,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cbc18882eda0b44cfa3a4dac5577f229, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  LogfolderPath: "/Users/x22036xx/Desktop/\u7814\u7A76\u5BA4\u95A2\u9023/Viewer/setting/deserialize-rrs_log-cs/output"
+  LogfolderPath: "/Users/x22036xx/Desktop/\u7814\u7A76\u5BA4\u95A2\u9023/Viewer/Log/berlin/output"
   InterfaceType: key
 --- !u!4 &298378966
 Transform:
@@ -1755,11 +1755,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2810827723386994177, guid: 344e5bc5b26a34542848678562e23c45, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.0030059814
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2810827723386994177, guid: 344e5bc5b26a34542848678562e23c45, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.9548992
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2810827723386994177, guid: 344e5bc5b26a34542848678562e23c45, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2234,6 +2234,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 988251983}
+  - component: {fileID: 988251984}
   m_Layer: 0
   m_Name: player
   m_TagString: Untagged
@@ -2250,13 +2251,26 @@ Transform:
   m_GameObject: {fileID: 988251982}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 250.003, y: 0.9548992, z: 120}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 350872052}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &988251984
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 988251982}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d89cbfe824eba423283119569239dcff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 0}
 --- !u!1 &989496220
 GameObject:
   m_ObjectHideFlags: 0
@@ -2976,7 +2990,7 @@ Transform:
   m_GameObject: {fileID: 1429246308}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.0030059814, y: 250, z: -0.07260132}
+  m_LocalPosition: {x: 0, y: 250, z: 0}
   m_LocalScale: {x: 10, y: 10, z: 10}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scripts/OverviewCamera.cs
+++ b/Assets/Scripts/OverviewCamera.cs
@@ -14,11 +14,13 @@ public class OverviewCamera : MonoBehaviour
     int? Max_Y = null, Min_Y = null;
     Camera cam;
     PlaneManager planeManager;
+    PlayerStartPosition playerStartPosition;
 
     void Awake()
     {
         cam = GetComponent<Camera>();
         planeManager = FindObjectOfType<PlaneManager>();
+        playerStartPosition = FindObjectOfType<PlayerStartPosition>();
     }
 
     public void SetLogFolderPath(string path)
@@ -113,6 +115,8 @@ public class OverviewCamera : MonoBehaviour
             //PlaneManagerスクリプトのsetPlane関数に中心座標，横幅，縦幅を渡して実行
             planeManager.setPlane(center, width, height);
 
+            //PlayerStartPositionスクリプトのsetStartPositionにcenterX, centerZを渡して実行
+            playerStartPosition.setCenterPosition(centerX, centerZ, width, height);
             
             // Cameraの位置を設定
             Vector3 posi = new Vector3(centerX, CalculateCameraHeight(width, height), centerZ);

--- a/Assets/Scripts/PlayerStartPosition.cs
+++ b/Assets/Scripts/PlayerStartPosition.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerStartPosition : MonoBehaviour
+{
+    public GameObject player;
+    Vector3 posi = new Vector3();
+    float centerX = 0;
+    float centerZ = 0;
+    float radius = 0;
+
+    void Awake()
+    {
+        if(player == null) player = this.gameObject;
+    }
+    public void setCenterPosition(float X, float Z, float width, float height)
+    {
+        centerX = X;
+        centerZ = Z;
+
+        //半径のセット
+        if(width < height)
+        {
+            radius = height / 2f / 2f;
+        }
+        else
+        {
+            radius = width / 2f / 2f;
+        }
+    }
+
+    public bool check(int x, int y)
+    {
+        posi = player.transform.position;
+        float px = x / 1000f;
+        float pz = y / 1000f;
+        float dx = px - centerX;
+        float dz = pz - centerZ;
+        float distance = Mathf.Sqrt(dx * dx + dz * dz);
+
+        if(distance < radius) //道路が半径の内側にある場合
+        {
+            posi.x = px;
+            posi.z = pz;
+            player.transform.position = posi;
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+}

--- a/Assets/Scripts/PlayerStartPosition.cs.meta
+++ b/Assets/Scripts/PlayerStartPosition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d89cbfe824eba423283119569239dcff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/RoadMesh.cs
+++ b/Assets/Scripts/RoadMesh.cs
@@ -9,20 +9,30 @@ public class RoadMesh : MonoBehaviour
     private string logfolder;
     private List<Mesh> wallMeshes = new List<Mesh>(); //壁のメッシュリスト
     private List<Vector3> apexes;
+    bool flag = false;
+    PlayerStartPosition playerStartPosition;
+
+    void Awake()
+    {
+        playerStartPosition = FindObjectOfType<PlayerStartPosition>();
+    }
 
     void Start()
     {
         MeshFilter meshFilter = GetComponent<MeshFilter>();
         meshFilter.mesh = new Mesh(); // 初期化
 
-        Setting setting = FindObjectOfType<Setting>();
-        logfolder = setting.LogfolderPath;
         LoadInitialConditions(); // 初期状態読み込み
 
         CombineAllMeshes(); // すべての壁を統合
     }
 
-    void LoadInitialConditions()
+    public void SetLogFolderPath(string path)
+    {
+        logfolder = path;
+    }
+
+    public void LoadInitialConditions()
     {
         string filePath = logfolder + "/INITIAL_CONDITIONS.json";
         if (File.Exists(filePath))
@@ -40,6 +50,7 @@ public class RoadMesh : MonoBehaviour
                     int apexesCount = 0;
                     
                     Vector3 position = new Vector3();
+                    int x = 0, y = 0;
 
                     foreach (var prop in entity["properties"])
                     {
@@ -56,8 +67,15 @@ public class RoadMesh : MonoBehaviour
                                 apexesCount++;
                             }
                         }
+                        if (propUrn == URN.Property.X) x = prop["intValue"].ToObject<int>();
+                        if (propUrn == URN.Property.Y) y = prop["intValue"].ToObject<int>(); 
                     }
                     MakeFloorMesh(apexes, apexesCount);
+
+                    if(flag == false)
+                    {
+                        flag = playerStartPosition.check(x, y);
+                    }
                 }
             }
         }

--- a/Assets/Scripts/StepManager.cs
+++ b/Assets/Scripts/StepManager.cs
@@ -19,6 +19,7 @@ public class StepManager : MonoBehaviour
     BlockadeLoader blockadeLoader;
     OverviewCamera overviewCamera;
     RefugeCamera refugeCamera;
+    RoadMesh roadMesh;
 
     void Awake() //確実に準備させるもの
     {
@@ -29,6 +30,7 @@ public class StepManager : MonoBehaviour
         blockadeLoader = FindObjectOfType<BlockadeLoader>();
         overviewCamera = FindObjectOfType<OverviewCamera>();
         refugeCamera = FindObjectOfType<RefugeCamera>();
+        roadMesh = FindObjectOfType<RoadMesh>();
     }
 
     void Start()
@@ -56,6 +58,7 @@ public class StepManager : MonoBehaviour
         blockadeLoader.SetLogFolderPath(logfolder);
         overviewCamera.SetLogFolderPath(logfolder);
         refugeCamera.SetLogFolderPath(logfolder);
+        roadMesh.SetLogFolderPath(logfolder);
         simulation();
 
         // リセットボタンの設定
@@ -71,6 +74,7 @@ public class StepManager : MonoBehaviour
         civilianLoader.LoadInitialConditions();
         overviewCamera.SetOverviewCamera();
         refugeCamera.SetRefugeCamera();
+        roadMesh.LoadInitialConditions();
         
         StartStep(); // 一度だけ
     }


### PR DESCRIPTION
## 変更の概要

* プレイヤーのスタートの位置を自動で変更できるようにした

## なぜこの変更をするのか

* マップが変わると対応できなくなってしまう

## 変更内容

* PlayerStartPosition.csの追加
* 道路の座標を取得して中心から決まった半径内の道路の場合にそこにプレイヤーの初期位置を配置するようにした

## 影響範囲

**ユーザーに影響すること**
> 特になし

**メンバーに影響すること**
> 特になし

**システムに影響すること**
> プレイヤーの初期位置が変わる

## 使い方・再現手法
> 特になし

## 課題

* 瓦礫多すぎるところに配置されると死ぬ！

## 備考

* その他に伝えたいこと


以下レビュー用のチェックリスト
---

### コードスタイル・可読性
- [ ] コードが一貫したスタイルで書かれている
- [ ] 変数名・関数名が意味の通る名前になっている
- [ ] 不要なコメント・デバッグコードが残っていない

### 仕様・要件
- [ ] プルリク概要に「変更理由」が明確に書かれている
- [ ] 変更内容に「UI変更ならスクショ」「API変更ならリクエスト/レスポンス」が載っている
- [ ] 影響範囲・使い方が適切に記載されている

### 動作確認
- [ ] 変更部分の動作確認を手元で行っている
- [ ] 異常系（エラー発生時など）の考慮がされている

### 設計・実装
- [ ] 冗長なコード・重複コードがない
- [ ] 関数・クラスが単一責任になっている

### その他
- [ ] 「課題」「備考」に特にレビューしてほしいポイントが書かれている
